### PR TITLE
Fix example syntax in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ class { ::autosign:
   settings => {
     'general' => {
       'loglevel' => 'INFO',
-    }
+    },
     'jwt_token' => {
       'secret'   => 'hunter2'
       'validity' => '7200',


### PR DESCRIPTION
Simply fixing the syntax for the example basic implementation.
