### PR TITLE
Allow override of gem_provider

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -21,6 +21,7 @@ class autosign (
   $user         = $::autosign::params::user,
   $group        = $::autosign::params::group,
   $journalpath  = $::autosign::params::journalpath,
+  $gem_provider = $::autosign::params::gem_provider,
   $settings     = {},
 ) inherits ::autosign::params {
   validate_string($package_name)


### PR DESCRIPTION
Without this change, users are not able to set their own gem provider.
This is a problem in environment where the default params logic does not
yield the correct provider, such as in the case of using puppetserver.
This change surfaces the gem_provider param to the autosign class so
that the references to autosign::gem_provider work as expected.
