### PR TITLE
Params refactor

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -30,23 +30,27 @@ class autosign::params {
   if str2bool($::is_pe) {
     #Assuming PE 3
     $gem_provider = 'pe_gem'
-    $group,$user = 'pe-puppet'
+    $group = 'pe-puppet'
+    $user = 'pe-puppet'
   } else {
     if $::puppetversion and versioncmp($::puppetversion, '4.0.0') >= 0 {
       if $::pe_server_version
       {
         #Assuming PE 4+
       $gem_provider = 'puppet_gem'
-      $group,$user = 'pe-puppet'
+      $group = 'pe-puppet'
+      $user = 'pe-puppet'
       } else {
         #Assume Open Source Pupppet 4
         $gem_provider = 'puppet_gem'
-        $user,$group = 'puppet'
+        $user = 'puppet'
+        $group = 'puppet'
       }
     } else {
       #Assume Open Source Puppet 3
       $gem_provider = 'gem'
-      $user,$group = 'puppet'
+      $user = 'puppet'
+      $group = 'puppet'
     }
   }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -27,26 +27,27 @@ class autosign::params {
     }
   }
 
-  case $::puppetversion {
-    /^3\.\d\.\d$/: {
+  if str2bool($::is_pe) {
+    #Assuming PE 3
+    $gem_provider = 'pe_gem'
+    $group,$user = 'pe-puppet'
+  } else {
+    if $::puppetversion and versioncmp($::puppetversion, '4.0.0') >= 0 {
+      if $::pe_server_version
+      {
+        #Assuming PE 4+
+      $gem_provider = 'puppet_gem'
+      $group,$user = 'pe-puppet'
+      } else {
+        #Assume Open Source Pupppet 4
+        $gem_provider = 'puppet_gem'
+        $user,$group = 'puppet'
+      }
+    } else {
+      #Assume Open Source Puppet 3
       $gem_provider = 'gem'
-      $user = 'puppet'
-      $group = 'puppet'
+      $user,$group = 'puppet'
     }
-    /^4\.\d\.\d$/: {
-      $gem_provider = 'puppet_gem'
-      $user = 'puppet'
-      $group = 'puppet'
-    }
-    /^.*\(Puppet Enterprise 3\.\d+\.\d+\)$/: {
-      $gem_provider = 'pe_gem'
-      $group = 'pe-puppet'
-    }
-    /^.*\(Puppet Enterprise \d+\.\d+\.\d+\)$/: {
-      $gem_provider = 'puppet_gem'
-      $group = 'pe-puppet'
-    }
-    default: { fail("::autosign::params cannot determine which gem provider to use with puppet version '${::puppetversion}'") }
   }
 
   $settings = {


### PR DESCRIPTION
Newer puppet versions were not parsed correctly by the existing params.pp. This refactor of the params.pp will recognize newer versions of Puppet and PE and properly set gem provider, user and group to use. This module now requires puppetlabs\stdlib. 

Puppet 4 no longer includes the string `Puppet Enterprise` in the `$::puppetversion` variable. This method checks `is_pe` (fact from stdlib) which will be true if agent is PE 3.x. Otherwise it determines if Puppet 4 is open source or PE using the `pe_server_version` fact. 
