### PR TITLE
make Puppet version regex work for Puppet 5 too

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -33,7 +33,7 @@ class autosign::params {
       $user = 'puppet'
       $group = 'puppet'
     }
-    /^4\.\d+\.\d+$/: {
+    /^[45]\.\d+\.\d+$/: {
       $gem_provider = 'puppet_gem'
       $user = 'puppet'
       $group = 'puppet'


### PR DESCRIPTION
That regex broke again with Puppet 5 :(

Open to better solutions but this one should work (Rubular says it does).