### PR TITLE
Switched to using contain

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -27,7 +27,9 @@ class autosign (
   validate_string($package_name)
   validate_string($ensure)
 
-  class { '::autosign::install': } ->
-  class { '::autosign::config': } ~>
-  Class['::autosign']
+  contain ::autosign::install
+  contain ::autosign::config
+
+  Class['::autosign::install']
+  -> Class['::autosign::config']
 }


### PR DESCRIPTION
This is intended to fix a problem where setting a require on the class
declaration like below doesn't actually work.

```pupppet
class {'::autosign':
  ensure  => present,
  require => Package['gcc'],
}
```

Being able to do a require like this is needed so that GCC is installed
prior to the autosign gem.

Testing of this change is in progress now... do not merge until testing is complete. I'll post back with the results. Pinging @danielparks per his request.