### PR TITLE
Fix spelling and improve the 'validfor' description in the Task

### DIFF
--- a/tasks/generate_token.json
+++ b/tasks/generate_token.json
@@ -9,7 +9,7 @@
       "type": "Optional[Boolean]"
     },
     "validfor": {
-      "description": "autosign token validity period (default: 7200)",
+      "description": "autosign token validity period in seconds (default: 7200)",
       "type": "Optional[Integer]"
     },
     "certname": {

--- a/tasks/generate_token.sh
+++ b/tasks/generate_token.sh
@@ -3,7 +3,7 @@
 PATH="/opt/puppetlabs/puppetserver/bin:/opt/puppetlabs/puppet/bin:/opt/puppet/bin:/usr/local/bin:$PATH"
 
 
-# If we couldn't find an execuatble exit with a nice error
+# If we couldn't find an executable exit with a nice error
 if ! command -v autosign > /dev/null 2>&1 ; then
     (>&2 echo "Autosign executable could not be found. Is this the Puppet master?")
     exit 1
@@ -15,7 +15,7 @@ command=(
     --bare
 )
 
-# Set the token ot be reusable if required
+# Set the token to be reusable if required
 if [ "$PT_reusable" = "true" ] ; then
     command+=('--reusable')
 else


### PR DESCRIPTION
This commit fixes a couple minor spelling issues in the Task script as
well as specifies that the validfor option should be passed in as
seconds in the task description.