### PR TITLE
0.2.2: Add option to *not* manage the autosign package

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "danieldreier-autosign",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "author": "danieldreier",
   "summary": "Manage certificate autosigning using the autosign gem",
   "license": "Apache-2.0",


### PR DESCRIPTION
Ping @danieldreier and @rjpearce. This is solely for **#29 Provide a mechanism that allows the package to be un-managed**.