### PR TITLE
Sensitive type

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -5,3 +5,10 @@ Gemfile:
   required:
     ':development':
       - gem: autosign
+spec/default_facts.yml:
+  extra_facts:
+    pe_server_version: null
+    pe_logpath: null
+    pe_journalpath: null
+    pe_configpath: null
+    pe_build: null    

--- a/README.md
+++ b/README.md
@@ -145,7 +145,8 @@ Users wishing to generate tokens this way should run the task against the Puppet
 
 `manage_logfile`: Weather or not to manage the logfile
 
-`config`: Hash of config to use.
+`config`: Hash of config to use.  This can optionally be a Sensitive type as well but you must wrap the entire hash in Sensitive.  `Sensitive.new({config goes here})`.  The config will by default always be
+redacted even if not passing in Sensitive value. 
 
 
 ## Development

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -53,7 +53,7 @@ class autosign (
   Boolean              $manage_journalfile = $::autosign::params::manage_journalfile,
   Boolean              $manage_logfile     = $::autosign::params::manage_logfile,
   Boolean              $manage_package     = $::autosign::params::manage_package,
-  Hash                 $config             = {},
+  Variant[Sensitive[Hash], Hash] $config   = {},
 ) inherits ::autosign::params {
   contain ::autosign::install
   contain ::autosign::config

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -53,7 +53,7 @@ class autosign::params {
   $manage_journalfile = true
   $manage_logfile     = true
   $manage_package     = true
-  $config             = {
+  $config             = Sensitive.new({
     'general'   => {
       'loglevel' => 'INFO',
       'logfile'  => "${logpath}/autosign.log",
@@ -67,6 +67,6 @@ class autosign::params {
       # correctly, all the more reason to override it.
       'secret'      => fqdn_rand_string(30),
     },
-  }
+  })
 
 }

--- a/metadata.json
+++ b/metadata.json
@@ -40,7 +40,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.0.0 < 7.0.0"
+      "version_requirement": ">= 4.6.0 < 7.0.0"
     }
   ],
   "template-url": "file:///opt/puppetlabs/pdk/share/cache/pdk-templates.git",

--- a/spec/default_facts.yml
+++ b/spec/default_facts.yml
@@ -2,7 +2,12 @@
 #
 # Facts specified here will override the values provided by rspec-puppet-facts.
 ---
-concat_basedir: "/tmp"
+pe_server_version: null
+pe_logpath: null
+pe_journalpath: null
+pe_configpath: null
+pe_build: null
 ipaddress: "172.16.254.254"
+ipaddress6: "FE80:0000:0000:0000:AAAA:AAAA:AAAA"
 is_pe: false
 macaddress: "AA:AA:AA:AA:AA:AA"

--- a/templates/autosign.conf.epp
+++ b/templates/autosign.conf.epp
@@ -1,5 +1,6 @@
+<%- | 
+Hash $settings
+| -%>
 # autosign configuration is managed by Puppet
 # manual modifications to this file will be overrwitten
-<% require 'yaml' -%>
-<%= @settings.to_yaml %>
-
+<%= $settings.to_yaml %>


### PR DESCRIPTION
This PR does two things

1. Keeps the JWT secret from being displayed in pupppet logs, diffs, and puppetdb by using the Sensitive type through the entire compilation and storage cycle.  Users will see `redacted` when the autosign.conf file changes.  The user is not required to pass in a Sensitive type so that we can maintain backwards compatibility when passing in the config parameter.  If they choose to do this the jwt_secret will be exposed in puppetdb.  But the puppet logs will still be wrapped with a Sensitive type.  

Please not this does require puppet 4.6+ 