### PR TITLE
Add puppet 4 function

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,25 +83,25 @@ class { ::autosign:
 
 ## Usage
 
-The `gen_autosign_token` function allows you to generate temporary autosign
+The `autosign::gen_autosign_token()` function allows you to generate temporary autosign
 tokens in puppet. The syntax is:
 
 ```puppet
 # return a one-time token that is only valid for the foo.example.com certname
 # for the default validity as configured above.
-gen_autosign_token('foo.example.com')
+autosign::gen_autosign_token('foo.example.com')
 
 # return a one-time token that is only valid for foo.example.com for the
 # next 3600 seconds.
-gen_autosign_token('foo.example.com', 3600)
+autosign::gen_autosign_token('foo.example.com', 3600)
 
 # return a one-time token that is valid for any certname matching the regex
 # ^.*\.example\.com$ for the default validity period.
-gen_autosign_token('/^.*\.example\.com$/')
+autosign::gen_autosign_token('/^.*\.example\.com$/')
 
 # return a one-time token that is valid for any certname matching the regex
 # ^.*\.example\.com$ for the next week (604800 seconds).
-gen_autosign_token('/.*\.example\.com/', 604800)
+autosign::gen_autosign_token('/.*\.example\.com/', 604800)
 ```
 
 Each of these will return a string which should be added to the

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ A Basic configuration might look like the following. Do not use the default pass
 ```puppet
 ini_setting { 'policy-based autosigning':
   setting => 'autosign',
-  path    => "${confdir}/puppet.conf",
+  path    => "${::settings::confdir}/puppet.conf",
   section => 'master',
   value   => '/opt/puppetlabs/puppet/bin/autosign-validator',
   notify  => Service['pe-puppetserver'],
@@ -80,7 +80,8 @@ class { ::autosign:
   },
 }
 ```
-
+**NOTE** You may also want to add a notify parameter as well to restart the puppetserver.
+         `notify => Service['pe-puppetserver'] or notify => Service['puppetserver']`
 ## Usage
 
 The `autosign::gen_autosign_token()` function allows you to generate temporary autosign

--- a/lib/puppet/functions/autosign/gen_autosign_token.rb
+++ b/lib/puppet/functions/autosign/gen_autosign_token.rb
@@ -1,0 +1,70 @@
+# @summary
+#    Generate a JWT autosign token for use with the autosign gem's
+#    autosign policy executable.
+#
+#    Requires a hostname string as input. Token validity, the secret
+#    used to sign the token, and other settings are determined by settings in
+#    autosign.conf.
+#
+#
+# @param certname
+#   The certname to sign.  Can also be a regex to accept multiple certnames
+#
+# @param jwt_token_validity
+#   The token validity time is seconds
+#
+# @return [String] - the token value
+#
+# @example usage with the certname to get a token for
+#   autosign::gen_autosign_token('puppet.vm')
+#     => eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJkYXRhIjoie1wiY2VydG5hbWVcIjpcIjBm
+# @example  Certname and validity time
+#   autosign::gen_autosign_token('puppet.vm', 7200)
+#     => eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJkYXRhIjoie1wiY2VydG5hbWVcIjpcIjBm
+# @example Using a regex instead of a certname
+#   autosign::gen_autosign_token('*.puppet.vm')
+#     => eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJkYXRhIjoie1wiY2VydG5hbWVcIjpcIjBm
+Puppet::Functions.create_function(:'autosign::gen_autosign_token') do
+  dispatch :with_validity_time do
+    param 'String', :certname
+    param 'Integer', :jwt_token_validity
+  end
+
+  dispatch :without_validity_time do
+    param 'String', :certname
+  end
+
+  def with_validity_time(certname, jwt_token_validity)
+    generate_token(certname, jwt_token_validity)
+  end
+
+  def without_validity_time(certname)
+    generate_token(certname)
+  end
+
+  def generate_token(certname, jwt_token_validity = nil)
+    begin
+      require 'autosign'
+      require 'socket'
+      require 'logging'
+    rescue LoadError
+      raise(Puppet::Error, "Attempting to use autosign::gen_autosign_token() without the autosign gem.\nPlease run: puppetserver gem install autosign")
+    end
+
+    @logger = Logging.logger['Autosign']
+    @logger.level = :info
+    @logger.add_appenders Logging.appenders.stdout
+    config = Autosign::Config.new
+    jwt_token_validity ||= config.settings['jwt_token'].fetch('validity', 7200)
+
+    jwt_secret = ENV['JWT_TOKEN_SECRET'] || config.settings['jwt_token']['secret']
+
+    if jwt_secret.nil?
+      raise(Puppet::ParseError, 'autosign::gen_autosign_token(): cannot generate token. ' \
+            'No secret provided in /etc/autosign.conf or JWT_TOKEN_SECRET env variable')
+    end
+
+    token = Autosign::Token.new(certname, false, jwt_token_validity.to_i, Socket.gethostname.to_s, jwt_secret)
+    token.sign
+  end
+end

--- a/lib/puppet/parser/functions/gen_autosign_token.rb
+++ b/lib/puppet/parser/functions/gen_autosign_token.rb
@@ -1,7 +1,3 @@
-require 'autosign'
-require 'socket'
-require 'logging'
-
 module Puppet::Parser::Functions
   newfunction(:gen_autosign_token, type: :rvalue, doc: <<-EOS
     Generate a JWT autosign token for use with the autosign gem's
@@ -10,8 +6,18 @@ module Puppet::Parser::Functions
     Requires a boolean hostname string as input. Token validity, the secret
     used to sign the token, and other settings are determined by settings in
     autosign.conf.
+
+    This function is deprecated, please use autosign::gen_autosign_token().
     EOS
              ) do |arguments|
+    Puppet.warning('gen_autosign_token() is deprecated and will be removed in next release, please use the autosign::gen_autosign_token() instead')
+    begin
+      require 'autosign'
+      require 'socket'
+      require 'logging'
+    rescue LoadError
+      raise(Puppet::Error, "Attempting to use gen_autosign_token() without the autosign gem.\nPlease run: puppetserver gem install autosign")
+    end
     @logger = Logging.logger['Autosign']
     @logger.level = :info
     @logger.add_appenders Logging.appenders.stdout

--- a/spec/functions/autosign/gen_autosign_token_spec.rb
+++ b/spec/functions/autosign/gen_autosign_token_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+# accept a hostname and return a JSON web token, which is three base64
+# encoded strings separated by periods
+describe 'autosign::gen_autosign_token' do
+  random_string = rand(36**25).to_s(36)
+  ENV['JWT_TOKEN_SECRET'] = rand(36**25).to_s(36)
+
+  context 'accepts a hostname as the parameter' do
+    it { is_expected.to run.with_params(random_string).and_return(%r{^[^.]+\.[^.]+\.[^.]+$}) }
+  end
+
+  context 'accepts a hostname and TTL in seconds as parameters' do
+    it { is_expected.to run.with_params(random_string, rand(10_000)).and_return(%r{^[^.]+\.[^.]+\.[^.]+$}) }
+  end
+
+  context 'raises an error given incorrect parameters' do
+    it { is_expected.to run.with_params.and_raise_error(ArgumentError) }
+    it { is_expected.to run.with_params('hostname.example.com', 'not_an_integer').and_raise_error(ArgumentError) }
+    it { is_expected.to run.with_params('hostname.example.com', 3600, 'invalid_third_parameter').and_raise_error(ArgumentError) }
+  end
+end


### PR DESCRIPTION
This deprecates the older v3 function and adds a new function called autosign::gen_autosign_token() in its place. 

This also fixes some load time errors from occurring when the gem is not installed on the puppetserver.

This removes the need for #31 