### PR TITLE
Fixes #2 - use puppetserver_gem when installing on JVM puppetserver

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,5 +1,6 @@
 fixtures:
   repositories:
     stdlib: "https://github.com/puppetlabs/puppetlabs-stdlib.git"
+    puppetserver_gem: 'https://github.com/puppetlabs/puppetlabs-puppetserver_gem'
   symlinks:
     autosign: "#{source_dir}"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -43,17 +43,19 @@
 # @param settings Hash of setting to use.
 #
 class autosign (
-  String               $ensure             = $::autosign::params::ensure,
-  String               $package_name       = $::autosign::params::package_name,
-  Stdlib::Absolutepath $configfile         = $::autosign::params::configfile,
-  String               $user               = $::autosign::params::user,
-  String               $group              = $::autosign::params::group,
-  Stdlib::Absolutepath $journalpath        = $::autosign::params::journalpath,
-  String               $gem_provider       = $::autosign::params::gem_provider,
-  Boolean              $manage_journalfile = $::autosign::params::manage_journalfile,
-  Boolean              $manage_logfile     = $::autosign::params::manage_logfile,
-  Boolean              $manage_package     = $::autosign::params::manage_package,
-  Variant[Sensitive[Hash], Hash] $config   = {},
+  String               $ensure              = $::autosign::params::ensure,
+  String               $puppetserver_ensure = 'present',
+  Optional[String]     $gem_source          = undef,
+  String               $package_name        = $::autosign::params::package_name,
+  Stdlib::Absolutepath $configfile          = $::autosign::params::configfile,
+  String               $user                = $::autosign::params::user,
+  String               $group               = $::autosign::params::group,
+  Stdlib::Absolutepath $journalpath         = $::autosign::params::journalpath,
+  String               $gem_provider        = $::autosign::params::gem_provider,
+  Boolean              $manage_journalfile  = $::autosign::params::manage_journalfile,
+  Boolean              $manage_logfile      = $::autosign::params::manage_logfile,
+  Boolean              $manage_package      = $::autosign::params::manage_package,
+  Variant[Sensitive[Hash], Hash] $config    = {},
 ) inherits ::autosign::params {
   contain ::autosign::install
   contain ::autosign::config

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -6,9 +6,19 @@ class autosign::install {
 
   # install the autosign gem
   if $::autosign::manage_package {
-    package { $::autosign::package_name:
-      ensure   => $::autosign::ensure,
-      provider => $::autosign::gem_provider,
+    package {
+      default:
+        name   => $::autosign::package_name,
+        source => $::autosign::gem_source
+      ;
+      'autosign via puppet_gem':
+        ensure   => $::autosign::ensure,
+        provider => $::autosign::gem_provider,
+      ;
+      'autosign via puppetserver_gem':
+        ensure   => $::autosign::puppetserver_ensure,
+        provider => 'puppetserver_gem',
+      ;
     }
   }
 

--- a/metadata.json
+++ b/metadata.json
@@ -11,6 +11,10 @@
     {
       "name": "puppetlabs-stdlib",
       "version_requirement": ">= 4.0.0 < 7.0.0"
+    },
+    {
+      "name": "puppetlabs-puppetserver_gem",
+      "version_requirement": ">= 1.1.1 < 2.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/spec/classes/class_spec.rb
+++ b/spec/classes/class_spec.rb
@@ -16,7 +16,8 @@ describe 'autosign' do
         let(:params) { {} }
 
         it_behaves_like 'base case'
-        it { is_expected.to contain_package('autosign').with_ensure('present') }
+        it { is_expected.to contain_package('autosign via puppet_gem').with_ensure('present') }
+        it { is_expected.to contain_package('autosign via puppetserver_gem').with_ensure('present') }
       end
     end
   end
@@ -28,6 +29,8 @@ describe 'autosign' do
         let(:params) do
           {
             ensure: 'latest',
+            puppetserver_ensure: 'latest',
+            gem_source: 'https://rubygems.org',
             config: { 'jwt_token' => { 'secret' => 'hunter2' } },
           }
         end
@@ -42,7 +45,16 @@ describe 'autosign' do
 
         it_behaves_like 'base case'
 
-        it { is_expected.to contain_package('autosign').with_ensure('latest') }
+        it do
+          is_expected.to contain_package('autosign via puppet_gem')
+            .with('ensure' => 'latest',
+                  'source' => 'https://rubygems.org')
+        end
+        it do
+          is_expected.to contain_package('autosign via puppetserver_gem')
+            .with('ensure' => 'latest',
+                  'source' => 'https://rubygems.org')
+        end
         it { is_expected.to contain_file("#{base_configpath}/autosign.conf").with_ensure('file') }
         it { is_expected.to contain_file("#{base_journalpath}/autosign.journal").with_ensure('file') }
         it { is_expected.to contain_file('/var/log/autosign.log').with_ensure('file') }
@@ -60,7 +72,7 @@ describe 'autosign' do
         }
       end
 
-      it { expect { is_expected.to contain_package('autosign') }.to raise_error(Puppet::Error, %r{Nexenta not supported}) }
+      it { expect { is_expected.to contain_package('autosign via puppet_gem') }.to raise_error(Puppet::Error, %r{Nexenta not supported}) }
     end
   end
 
@@ -73,7 +85,8 @@ describe 'autosign' do
         let(:params) { {} }
 
         it_behaves_like 'base case'
-        it { is_expected.to contain_package('autosign').with_ensure('present') }
+        it { is_expected.to contain_package('autosign via puppet_gem').with_ensure('present') }
+        it { is_expected.to contain_package('autosign via puppetserver_gem').with_ensure('present') }
         it { is_expected.to contain_file('/var/log/puppetlabs/puppetserver/autosign.log').with_ensure('file') }
         it { is_expected.to contain_file('/etc/puppetlabs/puppetserver/autosign.conf').with_ensure('file') }
         it { is_expected.to contain_file('/opt/puppetlabs/server/autosign/autosign.journal').with_ensure('file') }
@@ -96,7 +109,7 @@ describe 'autosign' do
         end
 
         it_behaves_like 'base case'
-        it { is_expected.to contain_package('autosign').with_ensure('0.1.0') }
+        it { is_expected.to contain_package('autosign via puppet_gem').with_ensure('0.1.0') }
         it { is_expected.to contain_file('/etc/autosign1.conf').with_ensure('file') }
         it { is_expected.not_to contain_file('/var/lib/autosign/autosign.journal') }
         it { is_expected.not_to contain_file('/var/log/autosign.log') }
@@ -115,7 +128,7 @@ describe 'autosign' do
           }
         end
 
-        it { is_expected.not_to contain_package('autosign') }
+        it { is_expected.not_to contain_package('autosign via puppet_gem') }
       end
     end
   end


### PR DESCRIPTION
This allows control of the gem source and if the user wants to control installation of the puppetserver gem separately.