### PR TITLE
Update Readme, prep for v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 ## Puppet Autosign Changelog
 
+## 0.6.0
+* Voxpupuli integrations and namespace changes
+* Update the supported OS list in metadata
+* Fix broken tests
+* Updates README with Vox callouts
+
+## 0.5.0
+* Release before switch to voxpupuli
+* Support EL7-EL9
+* Support Puppet 7 and 8
+* Support stdlib 9.x
+* Use Voxpupuli Gemfile and some lint fixes
+* Use facts hash to avoid undefined variable errors
+
 ## 0.4.0
 * Fixes #2 - use puppetserver_gem when installing on JVM puppetserver
 * Fixes #17 - ${confdir} is not valid in Readme example

--- a/README.md
+++ b/README.md
@@ -1,21 +1,31 @@
-[![Build Status](https://travis-ci.org/danieldreier/puppet-autosign.svg?branch=master)](https://travis-ci.org/danieldreier/puppet-autosign) [![Puppet Forge](https://img.shields.io/puppetforge/dt/danieldreier/autosign.svg)](https://forge.puppetlabs.com/danieldreier/autosign) [![Puppet Forge](https://img.shields.io/puppetforge/v/danieldreier/autosign.svg)](https://forge.puppetlabs.com/danieldreier/autosign)
+[![Puppet Forge](https://img.shields.io/puppetforge/dt/voxpupuli/autosign.svg)](https://forge.puppetlabs.com/voxpupuli/autosign) [![Puppet Forge](https://img.shields.io/puppetforge/v/voxpupuli/autosign.svg)](https://forge.puppetlabs.com/voxpupuli/autosign)
+
+## Switch to Vox Pupuli (PLEASE READ)
+This module has recently moved to VoxPupuli and all further development will be handled by VoxPupuli contributors.  🎉
+
+Prior to this handover the code was tagged to `v0.4.0` with some outstanding changes that were never released to the forge.  These additional changes are now tagged to `v0.5.0` with an associated branch of `v0.5.0-branch`.
+
+- 👉 If you are dependent on the old forge module danieldrier-autosign use `v0.4.0`
+- 👉 If you are dependedent on the `v0.4.0` but want the recent unreleased updates use `v0.5.0`.
+- 👉 For the latest release of v0.5.0 with Post VoxPupuli integration use `v0.6.0`+
+- 👉 A future major release will bring a small breaking change, and will likely be a `v1.0.0` release
 
 ## Overview
 
-This module manages the [autosign gem](https://github.com/danieldreier/autosign), which facilitates [policy-based certificate signing](https://docs.puppetlabs.com/puppet/latest/reference/ssl_autosign.html#policy-based-autosigning) in Puppet.
+This module manages the [autosign gem](https://github.com/voxpupuli/autosign), which facilitates [policy-based certificate signing](https://docs.puppetlabs.com/puppet/latest/reference/ssl_autosign.html#policy-based-autosigning) in Puppet.
 
 ## Description
 
 This module:
 
-- installs and configures the [autosign gem](https://github.com/danieldreier/autosign)
+- installs and configures the [autosign gem](https://github.com/voxpupuli/autosign)
 - provides a puppet function to generate JWT tokens for autosigning, for example when provisioning VMs using Puppet
 
 ## Setup
 
 #### Install
 ```
-puppet module install danieldreier-autosign
+puppet module install voxpupuli-autosign
 ```
 
 ### What autosign affects
@@ -36,7 +46,7 @@ puppet module install danieldreier-autosign
 
 ### Setup Requirements
 
-This module does not configure puppet to do policy-based autosigning. See the [autosign gem](https://github.com/danieldreier/autosign#2-configure-master) or [puppet docs](https://docs.puppetlabs.com/puppet/latest/reference/ssl_autosign.html#policy-based-autosigning) for instructions on how to configure policy-based autosigning. In puppet, the configuration will probably look something like:
+This module does not configure puppet to do policy-based autosigning. See the [autosign gem](https://github.com/voxpupuli/autosign#2-configure-master) or [puppet docs](https://docs.puppetlabs.com/puppet/latest/reference/ssl_autosign.html#policy-based-autosigning) for instructions on how to configure policy-based autosigning. In puppet, the configuration will probably look something like:
 
 ```puppet
 ini_setting {'policy-based autosigning':
@@ -51,7 +61,8 @@ ini_setting {'policy-based autosigning':
 
 #### Install Module
 ```bash
-puppet module install danieldreier-autosign
+puppet module install danieldreier-autosign (legacy)
+puppet module install voxpupuli-autosign (New)
 ```
 
 #### Basic manifest

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "voxpupuli-autosign",
-  "version": "0.4.0",
+  "version": "0.6.0",
   "author": "Vox Pupuli",
   "summary": "Manage certificate autosigning using the autosign gem",
   "license": "Apache-2.0",


### PR DESCRIPTION
Since this module recently moved we need to release a few minor versions in specific order.  I have added some comments in the readme to communicate these changes with the user.  This PR doesn't change any code but helps folks navigate the recent change since there should have been a v0.5.0 release prior to moving to Vox.

```markdown
This module has recently moved to VoxPupuli and all further development will be handled by VoxPupuli contributors.  🎉

Prior to this handover the code was tagged to `v0.4.0` with some outstanding changes that were never released to the 
forge.  These additional changes are now tagged to `v0.5.0` with an associated branch of `v0.5.0-branch`.  

- 👉 If you are dependent on the old forge module danieldrier-autosign use `v0.4.0`
- 👉 If you are dependedent on the `v0.4.0` but want the recent unreleased updates use `v0.5.0`. 
- 👉 For the latest release of v0.5.0 with Post VoxPupuli integration use `v0.6.0`+
- 👉 A future major release will bring a small breaking change, and will likely be a `v1.0.0` release
```
