### PR TITLE
metadata.json: Fix module name: voxpupuli->puppet

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,5 +1,5 @@
 {
-  "name": "voxpupuli-autosign",
+  "name": "puppet-autosign",
   "version": "0.6.0",
   "author": "Vox Pupuli",
   "summary": "Manage certificate autosigning using the autosign gem",


### PR DESCRIPTION
for historic reasons, which I only discuss for a lot of cake, our forge namespace is `puppet`. metadata.json has to match, otherwise the forge will deny the upload.