### PR TITLE
Remove puppetlabs/puppetserver_gem dependency

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,5 +2,3 @@
 fixtures:
   repositories:
     stdlib: "https://github.com/puppetlabs/puppetlabs-stdlib.git"
-    puppetserver_gem: 'https://github.com/puppetlabs/puppetlabs-puppetserver_gem'
-

--- a/metadata.json
+++ b/metadata.json
@@ -11,10 +11,6 @@
     {
       "name": "puppetlabs-stdlib",
       "version_requirement": ">= 4.0.0 < 10.0.0"
-    },
-    {
-      "name": "puppetlabs-puppetserver_gem",
-      "version_requirement": ">= 1.1.1 < 2.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Since a few major releases, this provider is part of puppet itself. The module is deprecated and not required anymore.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
